### PR TITLE
use ty_date_format for date formats

### DIFF
--- a/src/zcl_text2tab_parser.clas.testclasses.abap
+++ b/src/zcl_text2tab_parser.clas.testclasses.abap
@@ -212,7 +212,7 @@ class ltcl_text2tab_parser_test implementation.
     data:
           lo type ref to zcl_text2tab_parser,
           lx type ref to zcx_text2tab_error,
-          lv_date_format type char4,
+          lv_date_format type zcl_text2tab_parser=>ty_date_format,
           ls_dummy       type ty_dummy,
           lt_dummy       type tt_dummy,
           lv_dummy       type i.

--- a/src/zcl_text2tab_utils.clas.testclasses.abap
+++ b/src/zcl_text2tab_utils.clas.testclasses.abap
@@ -161,7 +161,7 @@ class ltcl_text2tab_utils_test implementation.
   method validate_date_format_spec.
     data:
           lx type ref to zcx_text2tab_error,
-          lv_date_format type char4.
+          lv_date_format type zcl_text2tab_parser=>ty_date_format.
 
     do 3 times.
       case sy-index.


### PR DESCRIPTION
this removes the use of `CHAR4` data element